### PR TITLE
require regenerator-runtime

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,7 @@
+// NB: regeneratorRuntime must be defined globally!
+//     https://github.com/babel/babel/issues/9849
+require("regenerator-runtime/runtime");
+
 var babel = require("@babel/core");
 var babel_preset_env = require("@babel/preset-env");
 var babel_preset_typescript = require("@babel/preset-typescript");


### PR DESCRIPTION
This fixes the following error, introduced in #7.

    ReferenceError: regeneratorRuntime is not defined

https://github.com/babel/babel/issues/9849